### PR TITLE
feat: add mcp evaluation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ If you find our survey useful, please kindly cite our paper:
 | Prompt flow | Microsoft | [promptflow](https://github.com/microsoft/promptflow) | A set of development tools designed by Microsoft to simplify the end-to-end development cycle of AI applications based on LLMs, from conception, prototyping, testing, and evaluation to production deployment and monitoring. It makes prompt engineering easier and enables the development of product-level LLM applications. |
 | DeepEval | mr-gpt | [DeepEval](https://github.com/confident-ai/deepeval) | DeepEval is a simple-to-use, open-source LLM evaluation framework. Similar to Pytest but specialized for unit testing LLM outputs, it incorporates the latest research to evaluate LLM outputs based on metrics such as G-Eval, hallucination, answer relevance, RAGAS, etc., utilizing LLMs and various other NLP models that run locally on your machine for evaluation. |
 | CONNER | Tencent AI Lab | [CONNER](https://github.com/ChanLiang/CONNER) | CONNER is a comprehensive large model knowledge evaluation framework designed to systematically and automatically assess the information generated from six critical perspectives: factuality, relevance, coherence, informativeness, usefulness, and validity. |
+| mcpbr | greynewell | [mcpbr](https://github.com/greynewell/mcpbr) | The first benchmarking harness specifically for MCP servers. Evaluate MCP servers with Model Context Protocol Benchmark Runner to validate server performance and agentic capabilities. |
 
 ## Datasets or Benchmarks
 


### PR DESCRIPTION
Hi! Most tools here evaluate models, but this one evaluates the *context* provided by MCP servers. I thought it would be a good addition for the Tools section as agents move toward tool-use benchmarks.