### PR TITLE
Add FBA-Bench (agentic e-commerce sim benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ If you find our survey useful, please kindly cite our paper:
 | AgentBench | Tsinghua University | [AgentBench](https://github.com/THUDM/AgentBench) | AgentBench is a systematic benchmark evaluation tool for assessing LLMs as intelligent agents, highlighting the performance gap between commercial LLMs and open-source competitors (2023-08-01) |
 | AgentBench Reasoning and Decision-making Evaluation Leaderboard | THUDM | [AgentBench](https://github.com/THUDM/AgentBench) | Jointly launched by Tsinghua and multiple universities, it covers the reasoning and decision-making capabilities of models in different task environments, such as shopping, home, and operating systems |
 | ToolBench Tool Invocation Evaluation | Zhiyuan/Tsinghua | [ToolBench](https://github.com/OpenBMB/ToolBench) | Compares with tool fine-tuned models and ChatGPT to provide evaluation scripts |
+| FBA-Bench | FBA-Bench | [FBA-Bench Enterprise](https://github.com/Bender1011001/FBA-Bench-Enterprise) | Tick-based e-commerce simulation benchmark for agentic LLMs: one decision per simulated day with persistent state and feedback loops, stress-tested under shocks (price wars, supply chain disruptions). Scored by objective business outcomes (profit/ROI) and operational metrics (tokens/latency) (2026-02-10) |
 
 ### Code-Capabilities
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -327,6 +327,7 @@ If you find our survey useful, please kindly cite our paper:
 | AgentBench | Tsinghua University | [AgentBench](https://github.com/THUDM/AgentBench) | AgentBench is a systematic benchmark evaluation tool for assessing LLMs as intelligent agents, highlighting the performance gap between commercial LLMs and open-source competitors (2023-08-01) |
 | AgentBench Reasoning and Decision-making Evaluation Leaderboard | THUDM | [AgentBench](https://github.com/THUDM/AgentBench) | Jointly launched by Tsinghua and multiple universities, it covers the reasoning and decision-making capabilities of models in different task environments, such as shopping, home, and operating systems |
 | ToolBench Tool Invocation Evaluation | Zhiyuan/Tsinghua | [ToolBench](https://github.com/OpenBMB/ToolBench) | Compares with tool fine-tuned models and ChatGPT to provide evaluation scripts |
+| FBA-Bench | FBA-Bench | [FBA-Bench Enterprise](https://github.com/Bender1011001/FBA-Bench-Enterprise) | Tick-based e-commerce simulation benchmark for agentic LLMs: one decision per simulated day with persistent state and feedback loops, stress-tested under shocks (price wars, supply chain disruptions). Scored by objective business outcomes (profit/ROI) and operational metrics (tokens/latency) (2026-02-10) |
 
 ### Code-Capabilities
 


### PR DESCRIPTION
Adds FBA-Bench Enterprise to the Agent-Capabilities benchmark table.\n\nProject: https://github.com/Bender1011001/FBA-Bench-Enterprise\nLeaderboard: https://bender1011001.github.io/FBA-Bench-Enterprise/\n\nFBA-Bench is a tick-based e-commerce simulation benchmark for agentic LLMs (one decision per simulated day with persistent state and feedback loops), scored by objective business outcomes (profit/ROI) plus tokens/latency.