### PR TITLE
Add ShopPay Audit Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ If you find our survey useful, please kindly cite our paper:
 |            | MultiPL-E             | Princeton University     | Neural code generation                                 | Benchmarking neural code generation models                   | [link](https://github.com/nuprl/MultiPL-E )                  |
 |            | CodeXGLUE             | Microsoft                | Code intelligence                                      | Wide tasks covering: code-code, text-code, code-text and text-text | [link](https://github.com/microsoft/CodeXGLUE )              |
 |            | EvoCodeBench          | Peking University        | Evolving code generation benchmark                     | Aligned with real-world code repositories, evolving over time | [link](https://github.com/seketeam/EvoCodeBench )            |
+|        | ShopPay Audit Benchmark | Dmatut7 | Business-logic audit benchmark for AI coding agents | Spec-grounded payment/wallet/order defects with tests, answer key and scoring rubric | [link](https://github.com/Dmatut7/shoppay-audit-benchmark ) |
 
 
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -188,6 +188,7 @@ If you find our survey useful, please kindly cite our paper:
 |            | MultiPL-E             | Princeton University     | Neural code generation                                 | Benchmarking neural code generation models                   | [link](https://github.com/nuprl/MultiPL-E )                  |
 |            | CodeXGLUE             | Microsoft                | Code intelligence                                      | Wide tasks covering: code-code, text-code, code-text and text-text | [link](https://github.com/microsoft/CodeXGLUE )              |
 |            | EvoCodeBench          | Peking University        | Evolving code generation benchmark                     | Aligned with real-world code repositories, evolving over time | [link](https://github.com/seketeam/EvoCodeBench )            |
+|        | ShopPay Audit Benchmark | Dmatut7 | Business-logic audit benchmark for AI coding agents | Spec-grounded payment/wallet/order defects with tests, answer key and scoring rubric | [link](https://github.com/Dmatut7/shoppay-audit-benchmark ) |
 
 
 


### PR DESCRIPTION
Adds ShopPay Audit Benchmark to the coding benchmark section.

It is a compact open-source benchmark for evaluating whether AI coding agents can find business-logic defects from written product rules. It includes seeded payment/wallet/order defects, baseline tests, a maintainer answer key, and a 100-point scoring rubric.

Repo: https://github.com/Dmatut7/shoppay-audit-benchmark
Landing page: https://dmatut7.github.io/shoppay-audit-benchmark/
Release: https://github.com/Dmatut7/shoppay-audit-benchmark/releases/tag/v0.1.1